### PR TITLE
Renamed Blackfish class and made Response weak

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-final public class Blackfish {
+final public class BlackfishApp {
 
     public static let VERSION = "0.1.3"
 
@@ -126,7 +126,7 @@ final public class Blackfish {
     }
 }
 
-extension Blackfish: SocketServerDelegate {
+extension BlackfishApp: SocketServerDelegate {
     func socketServer(socketServer: SocketServer,
                       didRecieveRequest request: Request,
                                         withResponse response: Response) {
@@ -136,7 +136,7 @@ extension Blackfish: SocketServerDelegate {
 
 // MARK: - Public Methods
 
-extension Blackfish {
+extension BlackfishApp {
 
     public func listen(port inPort: Int = 80, handler: ((error: ErrorType?) -> ())? = nil) {
 
@@ -171,7 +171,7 @@ extension Blackfish {
 
 // MARK: - Routing
 
-extension Blackfish: Routing {
+extension BlackfishApp: Routing {
 
     public func use(path path: String, router: Router) {
         Route.createRoutesFromRouter(router, withPath: path)
@@ -245,7 +245,7 @@ extension Blackfish: Routing {
 
 // MARK: - RendererSupplier
 
-extension Blackfish: RendererSupplier {
+extension BlackfishApp: RendererSupplier {
     public func rendererForFile(filename: String) -> Renderer? {
 
         for (key, value) in renderers {

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -26,7 +26,7 @@ public class Response {
     public var cookies: [String: String] = [:]
     public var additionalHeaders: [String: String] = [:]
 
-    unowned let request: Request
+    weak var request: Request?
     unowned let responder: Responder
     weak var renderSupplier: RendererSupplier?
 
@@ -101,7 +101,7 @@ public class Response {
     }
 
     func headers() -> [String: String] {
-        var headers = ["Server" : "Blackfish \(Blackfish.VERSION)"]
+        var headers = ["Server" : "Blackfish \(BlackfishApp.VERSION)"]
 
         if self.cookies.count > 0 {
             var cookieString = ""

--- a/Sources/SocketServer.swift
+++ b/Sources/SocketServer.swift
@@ -111,7 +111,7 @@ extension SocketServer: Responder {
         let socket = response.socket
 
         defer { socket
-            response.request.fireOnFinish()
+            response.request?.fireOnFinish()
             socket.release()
         }
 


### PR DESCRIPTION
In case of controller method like in code below I got problem with code compilation because of ambiguous name of classes `Response` in `SwiftHTTP` and `Blackfish` frameworks. Naturally this can happen also for different frameworks. But problem is that `Blackfish` framework have class in `Application.swift` file with the same name = `Blackfish`. This leads to the situation where we can't use type alias or module name to explicitly mark class which we want to use like `Blackfish.Response` because swift firstly is searching for member in class `Blackfish`.
Second problem is that `unowned` member `response.request` in this case is becoming `nil` earlier than `response.request.fireOnFinish()` from `SocketServer.swift` wants to call it. I don't know clearly why it happens but I think this is related to client HTTP request and callbacks which can use different queues but it needs more investigation. For now I changed `unowned let` to `weak var` and this solving the problem.

``` swift
func stars(request: Request, response: Blackfish.Response) {
        let repo = request.data["repo"]
        let user = request.data["user"]
        guard let strongRepo = repo as? String,
            strongUser = user as? String else
        {
            response.status = .BadRequest
            response.send(text: "Bad params (repo and user required)")
            return
        }
        do {
            let opt = try HTTP.GET("https://api.github.com/repos/\(strongUser)/\(strongRepo)")
            opt.start { (res: SwiftHTTP.Response) in
                if let err = res.error {
                    print("error: \(err.localizedDescription)")
                    response.send(text: "Error occured: \(err.localizedDescription)")
                } else {
                    do {
                        let json = try NSJSONSerialization.JSONObjectWithData(res.data, options: .AllowFragments)
                        if let jsonDict = json as? [String: AnyObject],
                        stars = jsonDict["stargazers_count"] as? Int
                        {
                            do {
                                let badgeOpt = try HTTP.GET("https://img.shields.io/badge/stars-\(stars)-green.svg?style=flat")
                                badgeOpt.start{ (resBadge: SwiftHTTP.Response) in
                                    if let err = resBadge.error {
                                        print("error: \(err.localizedDescription)")
                                        response.send(text: "Error occured: \(err.localizedDescription)")
                                    } else {
                                        if let svgBadge = String(data: resBadge.data, encoding: NSUTF8StringEncoding) {
                                            response.send(html: svgBadge)
                                        } else {
                                            response.send(text: "No badge")
                                        }
                                    }
                                }
                            } catch {
                                response.send(text: "Error occured: \(error)")
                            }
                        } else {
                            response.send(text: "Problem with data serialization")
                        }
                    } catch {
                        print("Error serializing JSON: \(error)")
                        response.send(text: "Error occured: \(error)")
                    }
                }
            }
        } catch {
            response.send(text: "Got an error creating the request: \(error)")
        }
    }
```
