### PR TITLE
Fix sending status 200 instead of 404

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -104,7 +104,7 @@ final public class BlackfishApp {
                     handleRoutes([result], request: request, response: response)
                 } else {
                     response.status = .NotFound
-                    response.send(text: "Page not found")
+                    response.send()
                 }
             }
         }


### PR DESCRIPTION
When the request can't be handled the status is being set to `404`, but this will be immediately overwritten because calling `send(text:)` will set the status to `200`.
Therefore I suggest calling `send()` without an additional message.
