### PR TITLE
Improve statuses

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -103,8 +103,7 @@ final public class BlackfishApp {
                 if let result = routeManager.routeSingle(request) {
                     handleRoutes([result], request: request, response: response)
                 } else {
-                    response.status = .NotFound
-                    response.send()
+                    response.send(.NotFound)
                 }
             }
         }
@@ -272,7 +271,7 @@ extension BlackfishApp: Responder {
         let connection = response.connection
 
         var responseString = ""
-        responseString = "HTTP/1.1 \(response.status.code) \(response.reasonPhrase)\r\n"
+        responseString = "HTTP/1.1 \(response.status.code) \(response.status.description)\r\n"
         
         var headers = response.headers()
         


### PR DESCRIPTION
- The former `reasonPhrase` of `Response` is now the computed property
  `description` of `Status`
- Custom statuses can now be initialized with a custom description,
  which will then be returned by the `description` property
- Rather than always setting the status to 200, the convenience `send`
  methods have the additional `status` parameter now. It has a default
  value (200), so this change won’t effect existing code, but allows
  setting any status in future.
- The required `send` method accepts an optional `status` parameter
  now. This way, the status can be set by passing it to the method, but
  at the same time won’t overwrite a previously set status if not needed.
- When an error occurs in one of the convenience `send` methods, they
  will now call the `send(error:)` method and return.
